### PR TITLE
Fix adhoc timezone

### DIFF
--- a/lib/xronor/dsl.rb
+++ b/lib/xronor/dsl.rb
@@ -34,7 +34,7 @@ module Xronor
     end
 
     def every(frequency, options = {}, &block)
-      @result.jobs << Xronor::DSL::Job.new(frequency, options.merge(@result.options), &block).result
+      @result.jobs << Xronor::DSL::Job.new(frequency, @result.options.merge(options), &block).result
     end
 
     def job_template(template)

--- a/spec/fixtures/schedule.rb
+++ b/spec/fixtures/schedule.rb
@@ -22,6 +22,12 @@ every :day, at: '0:00 am' do
   rake "send_greeting_notification"
 end
 
+every :day, at: '0:00 am', timezone: "Europe/Berlin" do
+  name "Send notifications for Berlin"
+  description "Send notifications for Berlin"
+  rake "send_notification[Europe/Berlin]"
+end
+
 every :wednesday, at: '0:10 am' do
   name "Create new companies"
   rake "create_new_companies"

--- a/spec/lib/xronor/generator/crontab_spec.rb
+++ b/spec/lib/xronor/generator/crontab_spec.rb
@@ -5,11 +5,46 @@ module Xronor
     describe Crontab do
       describe ".generate" do
         let(:filename) do
-          fixture_path("schedule.rb")
+          "/path/to/schedule"
         end
 
         let(:options) do
           {}
+        end
+
+        before do
+          allow(Xronor::Parser).to receive(:parse).and_return([
+            double("job1",
+              name: "Send awesome mails",
+              description: "Send awesome mails",
+              schedule: "15 * * * *",
+              command: "/bin/bash -l -c 'bundle exec rake send_awesome_mail RAILS_ENV=production'",
+            ),
+            double("job2",
+              name: "Update Elasticsearch indices",
+              description: "Update Elasticsearch indices",
+              schedule: "10 * * * *",
+              command: "/bin/bash -l -c 'bundle exec rake update_elasticsearch RAILS_ENV=production'",
+            ),
+            double("job3",
+              name: "Send greeting notifications",
+              description: "Send greeting notifications for all users",
+              schedule: "0 15 * * *",
+              command: "/bin/bash -l -c 'bundle exec rake send_greeting_notification RAILS_ENV=production'",
+            ),
+            double("job4",
+              name: "Create new companies",
+              description: "Create new companies",
+              schedule: "10 15 * * 2",
+              command: "/bin/bash -l -c 'bundle exec rake create_new_companies RAILS_ENV=production'",
+            ),
+            double("job5",
+              name: "Healthcheck",
+              description: "Healthcheck",
+              schedule: "0 10 10,20 * *",
+              command: "/bin/bash -l -c 'bundle exec rake ping RAILS_ENV=production'",
+            ),
+          ])
         end
 
         it "should process ERB template" do

--- a/spec/lib/xronor/generator/erb_spec.rb
+++ b/spec/lib/xronor/generator/erb_spec.rb
@@ -5,7 +5,7 @@ module Xronor
     describe ERB do
       describe ".generate_all_in_one" do
         let(:filename) do
-          fixture_path("schedule.rb")
+          "/path/to/schedule"
         end
 
         let(:template) do
@@ -16,6 +16,41 @@ module Xronor
           {
             template: template,
           }
+        end
+
+        before do
+          allow(Xronor::Parser).to receive(:parse).and_return([
+            double("job1",
+              name: "Send awesome mails",
+              description: "Send awesome mails",
+              schedule: "15 * * * *",
+              command: "/bin/bash -l -c 'bundle exec rake send_awesome_mail RAILS_ENV=production'",
+            ),
+            double("job2",
+              name: "Update Elasticsearch indices",
+              description: "Update Elasticsearch indices",
+              schedule: "10 * * * *",
+              command: "/bin/bash -l -c 'bundle exec rake update_elasticsearch RAILS_ENV=production'",
+            ),
+            double("job3",
+              name: "Send greeting notifications",
+              description: "Send greeting notifications for all users",
+              schedule: "0 15 * * *",
+              command: "/bin/bash -l -c 'bundle exec rake send_greeting_notification RAILS_ENV=production'",
+            ),
+            double("job4",
+              name: "Create new companies",
+              description: "Create new companies",
+              schedule: "10 15 * * 2",
+              command: "/bin/bash -l -c 'bundle exec rake create_new_companies RAILS_ENV=production'",
+            ),
+            double("job5",
+              name: "Healthcheck",
+              description: "Healthcheck",
+              schedule: "0 10 10,20 * *",
+              command: "/bin/bash -l -c 'bundle exec rake ping RAILS_ENV=production'",
+            ),
+          ])
         end
 
         it "should process ERB template" do
@@ -41,7 +76,7 @@ module Xronor
 
       describe ".generate_per_job" do
         let(:filename) do
-          fixture_path("schedule.rb")
+          "/path/to/schedule"
         end
 
         let(:template) do
@@ -52,6 +87,41 @@ module Xronor
           {
             template: template,
           }
+        end
+
+        before do
+          allow(Xronor::Parser).to receive(:parse).and_return([
+            double("job1",
+              name: "Send awesome mails",
+              description: "Send awesome mails",
+              schedule: "15 * * * *",
+              command: "/bin/bash -l -c 'bundle exec rake send_awesome_mail RAILS_ENV=production'",
+            ),
+            double("job2",
+              name: "Update Elasticsearch indices",
+              description: "Update Elasticsearch indices",
+              schedule: "10 * * * *",
+              command: "/bin/bash -l -c 'bundle exec rake update_elasticsearch RAILS_ENV=production'",
+            ),
+            double("job3",
+              name: "Send greeting notifications",
+              description: "Send greeting notifications for all users",
+              schedule: "0 15 * * *",
+              command: "/bin/bash -l -c 'bundle exec rake send_greeting_notification RAILS_ENV=production'",
+            ),
+            double("job4",
+              name: "Create new companies",
+              description: "Create new companies",
+              schedule: "10 15 * * 2",
+              command: "/bin/bash -l -c 'bundle exec rake create_new_companies RAILS_ENV=production'",
+            ),
+            double("job5",
+              name: "Healthcheck",
+              description: "Healthcheck",
+              schedule: "0 10 10,20 * *",
+              command: "/bin/bash -l -c 'bundle exec rake ping RAILS_ENV=production'",
+            ),
+          ])
         end
 
         it "should process ERB template" do

--- a/spec/lib/xronor/parser_spec.rb
+++ b/spec/lib/xronor/parser_spec.rb
@@ -124,6 +124,12 @@ module Xronor
               command: "/bin/bash -l -c 'bundle exec rake send_greeting_notification RAILS_ENV=production'",
             },
             {
+              name: "Send notifications for Berlin",
+              description: "Send notifications for Berlin",
+              schedule: "0 23 * * *",
+              command: "/bin/bash -l -c 'bundle exec rake send_notification[Europe/Berlin] RAILS_ENV=production'",
+            },
+            {
               name: "Create new companies",
               description: "Create new companies",
               schedule: "10 15 * * 2",
@@ -140,7 +146,7 @@ module Xronor
           end
 
           jobs = described_class.parse(filename)
-          expect(jobs.length).to eq 5
+          expect(jobs.length).to eq 6
         end
       end
     end

--- a/spec/lib/xronor/parser_spec.rb
+++ b/spec/lib/xronor/parser_spec.rb
@@ -30,6 +30,12 @@ module Xronor
                 command: "/bin/bash -l -c 'bundle exec rake send_greeting_notification RAILS_ENV=production'",
               ),
               OpenStruct.new(
+                name: "Send notifications for Berlin",
+                description: "Send notifications for Berlin",
+                schedule: "0 23 * * *",
+                command: "/bin/bash -l -c 'bundle exec rake send_notification[Europe/Berlin] RAILS_ENV=production'",
+              ),
+              OpenStruct.new(
                 name: "Create new companies",
                 description: nil,
                 schedule: "10 15 * * 2",
@@ -70,6 +76,12 @@ module Xronor
               command: "/bin/bash -l -c 'bundle exec rake send_greeting_notification RAILS_ENV=production'",
             },
             {
+              name: "Send notifications for Berlin",
+              description: "Send notifications for Berlin",
+              schedule: "0 23 * * *",
+              command: "/bin/bash -l -c 'bundle exec rake send_notification[Europe/Berlin] RAILS_ENV=production'",
+            },
+            {
               name: "Create new companies",
               description: "Create new companies",
               schedule: "10 15 * * 2",
@@ -86,7 +98,7 @@ module Xronor
           end
 
           jobs = described_class.parse(filename)
-          expect(jobs.length).to eq 5
+          expect(jobs.length).to eq 6
         end
       end
 


### PR DESCRIPTION
## WHY

Timezone specification at job description is not reflected to output.

```ruby
every :day, at: '0:00 am', timezone: "Europe/Berlin" do
  name "Send notifications for Berlin"
  description "Send notifications for Berlin"
  rake "send_notification[Europe/Berlin]"
end
```

## WHAT

Reflect them correctly.