### PR TITLE
Use hyphen in files from ERB template

### DIFF
--- a/lib/xronor/generator/erb.rb
+++ b/lib/xronor/generator/erb.rb
@@ -14,7 +14,7 @@ module Xronor
 
           jobs.inject({}) do |result, job|
             @job = job
-            result[job.name.gsub(/[^\.\-_A-Za-z0-9]/, "_").downcase] = ::ERB.new(erb, nil, "-").result(binding)
+            result[job.name.gsub(/[^\.\-A-Za-z0-9]/, "-").downcase] = ::ERB.new(erb, nil, "-").result(binding)
             result
           end
         end

--- a/spec/fixtures/schedule.rb
+++ b/spec/fixtures/schedule.rb
@@ -22,7 +22,7 @@ every :day, at: '0:00 am' do
   rake "send_greeting_notification"
 end
 
-every :day, at: '0:00 am', timezone: "Europe/Berlin" do
+every :day, at: '0:00 am', timezone: "Etc/GMT-1" do
   name "Send notifications for Berlin"
   description "Send notifications for Berlin"
   rake "send_notification[Europe/Berlin]"

--- a/spec/lib/xronor/generator/erb_spec.rb
+++ b/spec/lib/xronor/generator/erb_spec.rb
@@ -126,19 +126,19 @@ module Xronor
 
         it "should process ERB template" do
           expect(described_class.generate_per_job(filename, options)).to eq({
-            "send_awesome_mails" => <<-EOS,
+            "send-awesome-mails" => <<-EOS,
 # Send awesome mails - Send awesome mails
 15 * * * * /bin/bash -l -c 'bundle exec rake send_awesome_mail RAILS_ENV=production'
  EOS
-            "update_elasticsearch_indices" => <<-EOS,
+            "update-elasticsearch-indices" => <<-EOS,
 # Update Elasticsearch indices - Update Elasticsearch indices
 10 * * * * /bin/bash -l -c 'bundle exec rake update_elasticsearch RAILS_ENV=production'
 EOS
-            "send_greeting_notifications" => <<-EOS,
+            "send-greeting-notifications" => <<-EOS,
 # Send greeting notifications - Send greeting notifications for all users
 0 15 * * * /bin/bash -l -c 'bundle exec rake send_greeting_notification RAILS_ENV=production'
 EOS
-            "create_new_companies" => <<-EOS,
+            "create-new-companies" => <<-EOS,
 # Create new companies - Create new companies
 10 15 * * 2 /bin/bash -l -c 'bundle exec rake create_new_companies RAILS_ENV=production'
 EOS


### PR DESCRIPTION
Kubernetes Pod name has a restriction not to use underscore. We have to replace it to valid characters.

> up to maximum length of 253 characters and consist of lower case alphanumeric characters, -, and .

In addition, Central European Summer Time (CEST) has begun from the last Sunday. Due to this, a test case parsing `Europe/Berlin` time has failed. I also fixed this.