### PR TITLE
Add helper method for Kubernetes Pod name

### DIFF
--- a/lib/xronor/job.rb
+++ b/lib/xronor/job.rb
@@ -3,6 +3,8 @@ module Xronor
     DOM_INDEX = 2
     DOW_INDEX = 4
 
+    POD_NAME_MAX_LENGTH = 253
+
     def initialize(name, description, schedule, command)
       @name = name
       @description = description
@@ -33,6 +35,10 @@ module Xronor
 
     def cloud_watch_rule_name(prefix)
       "#{prefix}#{@name}-#{hashcode}".gsub(/[^\.\-_A-Za-z0-9]/, "-").downcase
+    end
+
+    def k8s_pod_name
+      @name.gsub(/[^\.\-A-Za-z0-9]/, "-").downcase[0...POD_NAME_MAX_LENGTH]
     end
 
     private

--- a/spec/lib/xronor/job_spec.rb
+++ b/spec/lib/xronor/job_spec.rb
@@ -75,6 +75,10 @@ module Xronor
         let(:name) do
           "abcde12345abcde12345abcde12345abcde12345abcde12345abcde12345abcde12345abcde12345abcde12345abcde12345abcde12345abcde12345abcde12345abcde12345abcde12345abcde12345abcde12345abcde12345abcde12345abcde12345abcde12345abcde12345abcde12345abcde12345abcde12345abcde12345abcde12345abcde12345abcde12345abcde12345"
         end
+
+        it "should normalize job name for Kubernetes Pod name spec" do
+          expect(job.k8s_pod_name).to eq "abcde12345abcde12345abcde12345abcde12345abcde12345abcde12345abcde12345abcde12345abcde12345abcde12345abcde12345abcde12345abcde12345abcde12345abcde12345abcde12345abcde12345abcde12345abcde12345abcde12345abcde12345abcde12345abcde12345abcde12345abcde12345abc"
+        end
       end
     end
 

--- a/spec/lib/xronor/job_spec.rb
+++ b/spec/lib/xronor/job_spec.rb
@@ -64,6 +64,20 @@ module Xronor
       end
     end
 
+    describe "#k8s_pod_name" do
+      context "when name is enough short" do
+        it "should normalize job name for Kubernetes Pod name spec" do
+          expect(job.k8s_pod_name).to eq "create-new-companies"
+        end
+      end
+
+      context "when name is too long" do
+        let(:name) do
+          "abcde12345abcde12345abcde12345abcde12345abcde12345abcde12345abcde12345abcde12345abcde12345abcde12345abcde12345abcde12345abcde12345abcde12345abcde12345abcde12345abcde12345abcde12345abcde12345abcde12345abcde12345abcde12345abcde12345abcde12345abcde12345abcde12345abcde12345abcde12345abcde12345abcde12345"
+        end
+      end
+    end
+
     describe "#cloud_watch_rule_name" do
       let(:prefix) do
         "scheduler-"


### PR DESCRIPTION
https://kubernetes.io/docs/user-guide/identifiers/

> up to maximum length of 253 characters and consist of lower case alphanumeric characters, -, and .

Currently we have no way to normalize job name included in template.